### PR TITLE
Adding support for multi-doc YAML streams as input

### DIFF
--- a/y2j.sh
+++ b/y2j.sh
@@ -106,14 +106,9 @@ y2j() {
 		read -r -d '' script <<-"EOF"
 		# Python code here prefixed by hard tab
 		import sys, yaml, json;
-		import io;
-		input = sys.stdin.read()
-		stdin = io.BytesIO(input)
-		try:
-		  json.dump(yaml.load(stdin), sys.stdout, indent=4)
-		except yaml.composer.ComposerError:
-		  stdin.seek(0)
-		  json.dump( [doc for doc in yaml.load_all(stdin)], sys.stdout, indent=4)
+		for doc in yaml.load_all(sys.stdin):
+		  json.dump(doc, sys.stdout, indent=4)
+		  print ""
 EOF
 
 		python -c "$script" | (

--- a/y2j.sh
+++ b/y2j.sh
@@ -108,7 +108,7 @@ y2j() {
 		import sys, yaml, json;
 		for doc in yaml.load_all(sys.stdin):
 		  json.dump(doc, sys.stdout, indent=4)
-		  print ""
+		  print("")
 EOF
 
 		python -c "$script" | (


### PR DESCRIPTION
## Problem

Before this change, `y2j` crashes when passed a multi-document YAML stream
(e.g. multiple YAML objects separated with `---`) with stacktrace:

```
$ cat  /tmp/test-multi-doc.yaml
Object: 1
kind: Thing1
metadata:
  name: thing1

---
Object: 2
kind: Thing2
metadata:
  name: thing2

---
Object: 3
kind: Thing3
metadata:
  name: thing3

$ cat  /tmp/test-multi-doc.yaml | y2j
Traceback (most recent call last):
     File "<string>", line 1, in <module>
     File "/usr/local/lib/python3.4/site-packages/yaml/__init__.py", line 72, in load
       return loader.get_single_data()
     File "/usr/local/lib/python3.4/site-packages/yaml/constructor.py", line 35, in get_single_data
       node = self.get_single_node()
     File "/usr/local/lib/python3.4/site-packages/yaml/composer.py", line 43, in get_single_node
       event.start_mark)
   yaml.composer.ComposerError: expected a single document in the stream
     in "<stdin>", line 1, column 1
   but found another document
     in "<stdin>", line 13, column 1
```
## Solution

After making the change in this PR, it will first assume a single doc and try to use `yaml.load()`.
If this fails, the exception is handled and it will use `yaml.load_all()` instead.

Single document YAML files are still returned as a single top-level JSON object wrapped in: '{}'.
Multi-document YAML files are returned as an Array of the top-level YAML objects found: `[ {obj1}, {obj2} ]`
## Sample Output:

```
$ cat  /tmp/test-multi-doc.yaml  | ~/src/pub/y2j/y2j
[
    {
        "kind": "Thing1",
        "Object": 1,
        "metadata": {
            "name": "thing1"
        }
    },
    {
        "kind": "Thing2",
        "Object": 2,
        "metadata": {
            "name": "thing2"
        }
    },
    {
        "kind": "Thing3",
        "Object": 3,
        "metadata": {
            "name": "thing3"
        }
    }
]
```
